### PR TITLE
Get correct point name and address

### DIFF
--- a/lib/mondial_relay/parcel_shops/fetch_all/parse_line.rb
+++ b/lib/mondial_relay/parcel_shops/fetch_all/parse_line.rb
@@ -37,7 +37,7 @@ module MondialRelay
         private
 
         def name
-          line.slice(10, 31).strip
+          line.slice(336, 31).strip
         end
 
         def relais_number
@@ -45,15 +45,14 @@ module MondialRelay
         end
 
         def address
-          line.slice(336, 31).strip
-        end
-
-        def address_additional
           [
             line.slice(367, 31).strip,
             line.slice(398, 31).strip,
-            line.slice(429, 31).strip,
           ].reject { |line| line.empty? }.join(' ')
+        end
+
+        def address_additional
+          line.slice(429, 31).strip
         end
 
         def country

--- a/spec/mondial_relay/parcel_shops/fetch_all/parse_line_spec.rb
+++ b/spec/mondial_relay/parcel_shops/fetch_all/parse_line_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe MondialRelay::ParcelShops::FetchAll::ParseLine, '.for' do
 
   let(:relais_number) { '00105' }
   let(:name) { 'CHAUSSURES RICHE' }
-  let(:address) { 'CHAUSSURES RICHE' }
-  let(:address_additional) { 'FAUBOURG SAINT GERMAIN 18' }
+  let(:address) { 'FAUBOURG SAINT GERMAIN 18' }
+  let(:address_additional) { '' }
   let(:country) { 'BE' }
   let(:city) { 'COUVIN' }
   let(:postal_code) { '5660' }


### PR DESCRIPTION
Fix parsing point name & address.

It seems that the `name` from offset 11 is not being used at all. Otherwise, it could be used for internal usage.

I have compared our imported points with points from www.mondialrelay.fr site. Their format is:
 - the name is `address line 1` (offset 337)
 - the address is `address line 3` (offset 399)

However, the `address line 2` (offset 368) is always empty. I decided to make an `address` from `address line 2` and `address line 3`.

@vinted/shipping-backend 