### PR TITLE
Add default SFTP timeout

### DIFF
--- a/lib/mondial_relay/configuration.rb
+++ b/lib/mondial_relay/configuration.rb
@@ -11,6 +11,7 @@ module MondialRelay
 
     SFTP_HOST = 'sftp.mondialrelay.com'
     SFTP_RELAIS_PATH = '/depuismrelay/relais.txt'
+    SFTP_CONNECT_TIMEOUT = 10
 
     attr_accessor :api_url, :api_timeout, :api_max_retries,
       :enabled_services, :debug, :monitor,
@@ -29,6 +30,7 @@ module MondialRelay
 
       @sftp_host = SFTP_HOST
       @sftp_relais_path = SFTP_RELAIS_PATH
+      @sftp_connect_timeout = SFTP_CONNECT_TIMEOUT
 
       @debug = false
       @monitor = nil

--- a/lib/mondial_relay/sftp_client.rb
+++ b/lib/mondial_relay/sftp_client.rb
@@ -30,7 +30,7 @@ module MondialRelay
         password: password,
         non_interactive: true,
         port: SFTP_PORT,
-      }
+      }.compact
     end
 
     def connect_timeout

--- a/lib/mondial_relay/version.rb
+++ b/lib/mondial_relay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MondialRelay
-  VERSION = '6.2.1'
+  VERSION = '6.2.2'
 end

--- a/spec/mondial_relay/sftp_client_spec.rb
+++ b/spec/mondial_relay/sftp_client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MondialRelay::SftpClient do
         password: config.sftp_password,
         non_interactive: true,
         port: described_class::SFTP_PORT,
-      }
+      }.compact
     end
 
     before do


### PR DESCRIPTION
1. Adding a default SFTP timeout value.
2. Passing only present options to SFTP connection (prevents warnings).
3. Bumping patch version.

@vinted/shipping-backend 