### PR TITLE
Add temporarily field in response

### DIFF
--- a/lib/mondial_relay/parcel_shops/fetch_all/parse_line.rb
+++ b/lib/mondial_relay/parcel_shops/fetch_all/parse_line.rb
@@ -32,7 +32,8 @@ module MondialRelay
             latitude: latitude,
             longitude: longitude,
             business_hours: business_hours,
-            holiday_information: closure_periods,
+            holiday_information: holiday_information,
+            temporarily_closed: temporarily_closed?,
           }
         end
 
@@ -106,21 +107,14 @@ module MondialRelay
           }
         end
 
-        def closure_periods
-          holiday_information.push(final_closure_date).compact
+        def temporarily_closed?
+          return false if final_closure_date.blank?
+
+          true
         end
 
         def final_closure_date
-          ends_at = line.slice(72, 10).strip
-
-          return if ends_at.blank?
-
-          starts_at = Date.parse(ends_at) - 1
-
-          {
-            starts_at: starts_at.strftime(DATE_FORMAT),
-            ends_at: ends_at,
-          }
+          line.slice(72, 10).strip
         end
 
         def holiday_information

--- a/spec/mondial_relay/parcel_shops/fetch_all/parse_line_spec.rb
+++ b/spec/mondial_relay/parcel_shops/fetch_all/parse_line_spec.rb
@@ -84,6 +84,8 @@ RSpec.describe MondialRelay::ParcelShops::FetchAll::ParseLine, '.for' do
     ]
   end
 
+  let(:temporarily_closed) { false }
+
   let(:result) do
     {
       id: relais_number,
@@ -97,31 +99,19 @@ RSpec.describe MondialRelay::ParcelShops::FetchAll::ParseLine, '.for' do
       longitude: longitude,
       business_hours: business_hours,
       holiday_information: holiday_information,
+      temporarily_closed: temporarily_closed,
     }
   end
 
   it { is_expected.to eq(result) }
 
-  context 'with a final closure date' do
+  context 'with temporarily closed' do
     let(:line) do
       'D1RL00105 CHAUSSURES RICHE               521080676252108     D12.10.201702.02.202010.07.202011.07.2020                                                            21.07.2018                                                                                           Ma/Me/J/V/S 9:30-12 13:30-18                                  9904X     XCHAUSSURES RICHE                                              FAUBOURG SAINT GERMAIN 18                                     5660 COUVIN                    521081700N0000000000000000093012001330180009301200133018000930120013301800093012001330180009301200133018000000000000000000NONNNOOBE                         003001      R09245127+0500518840+0044950080                                                                                                                                                                                                                                                                                                                      '
     end
 
-    let(:holiday_information) do
-      [
-        {
-          starts_at: '10.07.2020',
-          ends_at: '11.07.2020',
-        },
-        {
-          starts_at: '01.02.2020',
-          ends_at: '02.02.2020',
-        },
-      ]
-    end
+    let(:temporarily_closed) { true }
 
-    it 'parses final closure date' do
-      expect(subject[:holiday_information]).to eq(holiday_information)
-    end
+    it { is_expected.to eq(result) }
   end
 end


### PR DESCRIPTION
The `final_closure_date` tells when the parcel shops was closed. It means that the parcel shop is temporarily closed.

@vinted/shipping-backend 